### PR TITLE
Added support for risk management xml endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,47 @@ The following gateways are provided by this package:
     }
 
 ```
+
+
+### NAB Transact SecureXML API with Risk Management
+
+```php
+    use Omnipay\Omnipay;
+    use Omnipay\Common\CreditCard;
+
+    $gateway = Omnipay::create('NABTransact_SecureXML');
+    $gateway->setMerchantId('XYZ0010');
+    $gateway->setTransactionPassword('abcd1234');
+    $gateway->setTestMode(true);
+    $gateway->setRiskManagement(true);
+
+    $card = new CreditCard([
+            'firstName' => 'Sujip',
+            'lastName' => 'Thapa',
+            'number'      => '4444333322221111',
+            'expiryMonth' => '06',
+            'expiryYear'  => '2030',
+            'cvv'         => '123',
+        ]
+    );
+
+    $transaction = $gateway->purchase([
+            'amount'        => '10.00',
+            'currency'      => 'AUD',
+            'transactionId' => 'XYZ100',
+            'card'          => $card,
+            'ip'            => '1.1.1.1',
+        ]
+    );
+
+    $response = $transaction->send();
+
+    if ($response->isSuccessful()) {
+        echo sprintf('Transaction %s was successful!', $response->getTransactionReference());
+    } else {
+        echo sprintf('Transaction %s failed: %s', $response->getTransactionReference(), $response->getMessage());
+    }
+
 ### NAB Transact DirectPost v2
 
 ```php

--- a/src/Message/SecureXMLRiskPurchaseRequest.php
+++ b/src/Message/SecureXMLRiskPurchaseRequest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Omnipay\NABTransact\Message;
+
+/**
+ * NABTransact SecureXML Purchase Request.
+ */
+class SecureXMLRiskPurchaseRequest extends SecureXMLAbstractRequest
+{
+    /**
+     * @var string
+     */
+    public $liveEndpoint = 'https://transact.nab.com.au/riskmgmt/payment';
+
+    /**
+     * @var string
+     */
+    public $testEndpoint = 'https://demo.transact.nab.com.au/riskmgmt/payment';
+
+    /**
+     * @var int
+     */
+    protected $txnType = 0;
+
+    /**
+     * @var array
+     */
+    protected $requiredFields = ['amount', 'card', 'transactionId', 'ip'];
+
+    public function setIp($value)
+    {
+        $this->setParameter('ip', $value);
+    }
+
+    public function getIp()
+    {
+        return $this->getParameter('ip');
+    }
+
+    /**
+     * @return string
+     */
+    public function getData()
+    {
+        $xml = $this->getBasePaymentXMLWithCard();
+
+        $buyer = $xml->addChild('BuyerInfo');
+        $buyer->addChild('ip', $this->getIp('ip'));
+        $card = $this->getCard();
+        if ($firstName = $card->getFirstName()) {
+            $buyer->addChild('firstName', $firstName);
+        }
+        if ($lastName = $card->getLastName()) {
+            $buyer->addChild('firstName', $lastName);
+        }
+        if ($postCode = $card->getBillingPostcode()) {
+            $buyer->addChild('zipcode', $postCode);
+        }
+        if ($city = $card->getBillingCity()) {
+            $buyer->addChild('town', $city);
+        }
+        if ($country = $card->getBillingCountry()) {
+            $buyer->addChild('billingCountry', $country);
+        }
+        if ($email = $card->getEmail()) {
+            $buyer->addChild('emailAddress', $email);
+        }
+        return $xml;
+    }
+}

--- a/src/Message/SecureXMLRiskPurchaseRequest.php
+++ b/src/Message/SecureXMLRiskPurchaseRequest.php
@@ -65,6 +65,7 @@ class SecureXMLRiskPurchaseRequest extends SecureXMLAbstractRequest
         if ($email = $card->getEmail()) {
             $buyer->addChild('emailAddress', $email);
         }
+
         return $xml;
     }
 }

--- a/src/SecureXMLGateway.php
+++ b/src/SecureXMLGateway.php
@@ -38,6 +38,21 @@ class SecureXMLGateway extends AbstractGateway
     {
         return $this->setParameter('merchantId', $value);
     }
+    /**
+     * @return string
+     */
+    public function getRiskManagement()
+    {
+        return $this->getParameter('riskManagement');
+    }
+
+    /**
+     * @param $value
+     */
+    public function setRiskManagement($value)
+    {
+        return $this->setParameter('riskManagement', $value);
+    }
 
     /**
      * @return string
@@ -82,6 +97,9 @@ class SecureXMLGateway extends AbstractGateway
      */
     public function purchase(array $parameters = [])
     {
+        if ($this->getRiskManagement()) {
+            return $this->createRequest('\Omnipay\NABTransact\Message\SecureXMLRiskPurchaseRequest', $parameters);
+        }
         return $this->createRequest('\Omnipay\NABTransact\Message\SecureXMLPurchaseRequest', $parameters);
     }
 

--- a/src/SecureXMLGateway.php
+++ b/src/SecureXMLGateway.php
@@ -38,6 +38,7 @@ class SecureXMLGateway extends AbstractGateway
     {
         return $this->setParameter('merchantId', $value);
     }
+
     /**
      * @return string
      */
@@ -100,6 +101,7 @@ class SecureXMLGateway extends AbstractGateway
         if ($this->getRiskManagement()) {
             return $this->createRequest('\Omnipay\NABTransact\Message\SecureXMLRiskPurchaseRequest', $parameters);
         }
+
         return $this->createRequest('\Omnipay\NABTransact\Message\SecureXMLPurchaseRequest', $parameters);
     }
 

--- a/tests/SecureXMLGatewayTest.php
+++ b/tests/SecureXMLGatewayTest.php
@@ -57,7 +57,7 @@ class SecureXMLGatewayTest extends GatewayTestCase
         $this->assertSame('25.00', $request->getAmount());
         $this->assertContains(
             '<BuyerInfo><ip>1.1.1.1</ip><firstName>Example</firstName><firstName>User</firstName><zipcode>12345</zipcode><town>Billstown</town><billingCountry>US</billingCountry></BuyerInfo>',
-            (string)$request->getData()->asXml()
+            (string) $request->getData()->asXml()
         );
     }
 

--- a/tests/SecureXMLGatewayTest.php
+++ b/tests/SecureXMLGatewayTest.php
@@ -47,6 +47,20 @@ class SecureXMLGatewayTest extends GatewayTestCase
         $this->assertSame('10.00', $request->getAmount());
     }
 
+    public function testPurchaseRiskManaged()
+    {
+        $gateway = clone $this->gateway;
+        $gateway->setRiskManagement(true);
+        $request = $gateway->purchase(['card' => $this->getValidCard(), 'transactionId' => 'Test1234', 'ip' => '1.1.1.1', 'amount' => '25.00']);
+
+        $this->assertInstanceOf('\Omnipay\NABTransact\Message\SecureXMLRiskPurchaseRequest', $request);
+        $this->assertSame('25.00', $request->getAmount());
+        $this->assertContains(
+            '<BuyerInfo><ip>1.1.1.1</ip><firstName>Example</firstName><firstName>User</firstName><zipcode>12345</zipcode><town>Billstown</town><billingCountry>US</billingCountry></BuyerInfo>',
+            (string)$request->getData()->asXml()
+        );
+    }
+
     public function testRefund()
     {
         $request = $this->gateway->refund(['amount' => '10.00', 'transactionId' => 'Order-YKHU67']);


### PR DESCRIPTION
> 2.6.2 Risk Management
> Risk Management features assist merchants in evaluating the risk of a transaction based on rules set within the NAB Transact management portal. Each Risk Management payment request must be submitted to one of the Risk Management payment URLs listed in Section 2.6.2.3. In addition each request will require further fields submitted in order to evaluate against the configured ruleset.

Patch supports sending requests via Risk Management ruleset