### PR TITLE
Fix Direct Post fingerprint field order for surcharge, MCR and EMV 3DS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,14 @@
   },
   "require": {
     "php": "^7.2 || ^8.0",
-    "omnipay/common": "^3"
+    "nyholm/psr7": "^1.8",
+    "omnipay/common": "^3",
+    "php-http/httplug": "^2.4",
+    "symfony/http-client": "^8.1",
+    "symfony/http-foundation": "^2.1 || ^3 || ^4 || ^5 || ^6 || ^7 || ^8"
   },
   "require-dev": {
-    "phpstan/phpstan": "^1.12",
+    "phpstan/phpstan": "^2.0",
     "phpunit/phpunit": "^8.5.14 || ^9.6",
     "squizlabs/php_codesniffer": "^3"
   },

--- a/src/Message/DirectPostAbstractRequest.php
+++ b/src/Message/DirectPostAbstractRequest.php
@@ -111,19 +111,31 @@ abstract class DirectPostAbstractRequest extends AbstractRequest
             'EPS_TIMESTAMP',
         ];
 
-        if (isset($data['EPS_ORDERID'])) {
+        $hasCardScheme = isset($data['EPS_CARDSCHEME']);
+        $hasOrderId = isset($data['EPS_ORDERID']);
+        $hasSurcharge = isset($data['EPS_SURCHARGEAMOUNT']);
+
+        // Field order follows the NAB Direct Post v2 fingerprint specification
+        // (sections 2.3.6.2 - 2.3.6.4). EPS_SURCHARGEENABLED is a form-only flag
+        // and is never part of the fingerprint. The surcharge values are always
+        // ordered fee, rate, amount. When the MCR card scheme is present it takes
+        // the position immediately after the timestamp and the EMV order id moves
+        // to the end of the hashable string; otherwise the EMV order id precedes
+        // any surcharge values.
+        if ($hasCardScheme) {
+            $fields[] = 'EPS_CARDSCHEME';
+        } elseif ($hasOrderId) {
             $fields[] = 'EPS_ORDERID';
         }
 
-        if (isset($data['EPS_CARDSCHEME'])) {
-            $fields[] = 'EPS_CARDSCHEME';
+        if ($hasSurcharge) {
+            $fields[] = 'EPS_SURCHARGEFEE';
+            $fields[] = 'EPS_SURCHARGERATE';
+            $fields[] = 'EPS_SURCHARGEAMOUNT';
         }
 
-        if (isset($data['EPS_SURCHARGEENABLED'])) {
-            $fields[] = 'EPS_SURCHARGEENABLED';
-            $fields[] = 'EPS_SURCHARGEAMOUNT';
-            $fields[] = 'EPS_SURCHARGERATE';
-            $fields[] = 'EPS_SURCHARGEFEE';
+        if ($hasCardScheme && $hasOrderId) {
+            $fields[] = 'EPS_ORDERID';
         }
 
         $hashable = [];

--- a/src/Message/DirectPostWebhookRequest.php
+++ b/src/Message/DirectPostWebhookRequest.php
@@ -39,7 +39,7 @@ class DirectPostWebhookRequest extends DirectPostAbstractRequest
 
         if ($fingerprint !== $this->generateResponseFingerprint($data)) {
             $existing = isset($data['restext']) ? trim((string) $data['restext']) : '';
-            $data['restext'] = $existing === '' ? 'Invalid fingerprint.' : $existing.', Invalid fingerprint.';
+            $data['restext'] = $existing === '' ? 'Invalid fingerprint.' : $existing . ', Invalid fingerprint.';
             $data['summarycode'] = 3;
         }
 

--- a/src/Message/EMV3DSOrderRequest.php
+++ b/src/Message/EMV3DSOrderRequest.php
@@ -98,14 +98,14 @@ class EMV3DSOrderRequest extends AbstractRequest
             throw new InvalidRequestException('Unable to encode EMV 3DS order payload.');
         }
 
-        $authorization = base64_encode($this->getMerchantId().':'.$this->getTransactionPassword());
+        $authorization = base64_encode($this->getMerchantId() . ':' . $this->getTransactionPassword());
 
         $response = $transport->send(
             'POST',
             $this->getEndpoint(),
             [
                 'Content-Type'  => 'application/json; charset=UTF-8',
-                'Authorization' => 'Basic '.$authorization,
+                'Authorization' => 'Basic ' . $authorization,
             ],
             $payload,
             $this->getTimeoutSeconds()

--- a/src/Message/UnionPayPurchaseRequest.php
+++ b/src/Message/UnionPayPurchaseRequest.php
@@ -29,8 +29,8 @@ class UnionPayPurchaseRequest extends DirectPostAbstractRequest
             throw new InvalidRequestException('UPOP does not support EMV 3DS transaction types.');
         }
 
-        if ($this->getCurrency() !== null) {
-            $currency = strtoupper((string) $this->getCurrency());
+        if ($currency = $this->getCurrency()) {
+            $currency = strtoupper((string) $currency);
             if (!in_array($currency, ['AUD', 'CNY'], true)) {
                 throw new InvalidRequestException('UPOP only supports AUD or CNY currencies.');
             }
@@ -50,7 +50,7 @@ class UnionPayPurchaseRequest extends DirectPostAbstractRequest
      */
     public function sendData($data)
     {
-        $redirectUrl = $this->getEndpoint().'?'.http_build_query($data);
+        $redirectUrl = $this->getEndpoint() . '?' . http_build_query($data);
 
         return $this->response = new UnionPayPurchaseResponse($this, $data, $redirectUrl);
     }

--- a/src/Transport/CurlTransport.php
+++ b/src/Transport/CurlTransport.php
@@ -25,7 +25,7 @@ final class CurlTransport implements TransportInterface
 
         $formattedHeaders = [];
         foreach ($headers as $name => $value) {
-            $formattedHeaders[] = $name.': '.$value;
+            $formattedHeaders[] = $name . ': ' . $value;
         }
 
         $options = [
@@ -45,7 +45,7 @@ final class CurlTransport implements TransportInterface
             $message = curl_error($handle);
             curl_close($handle);
 
-            throw new RuntimeException('cURL transport request failed: '.$message);
+            throw new RuntimeException('cURL transport request failed: ' . $message);
         }
 
         $statusCode = (int) curl_getinfo($handle, CURLINFO_RESPONSE_CODE);

--- a/src/Transport/OmnipayHttpClientTransport.php
+++ b/src/Transport/OmnipayHttpClientTransport.php
@@ -32,13 +32,9 @@ final class OmnipayHttpClientTransport implements TransportInterface
     {
         $response = $this->httpClient->request(strtoupper($method), $url, $headers, $body);
 
-        $statusCode = method_exists($response, 'getStatusCode') ? (int) $response->getStatusCode() : 200;
-        $responseBody = '';
-
-        if (method_exists($response, 'getBody')) {
-            $responseBody = (string) $response->getBody();
-        }
-
-        return new TransportResponse($statusCode, $responseBody);
+        return new TransportResponse(
+            (int) $response->getStatusCode(),
+            (string) $response->getBody()
+        );
     }
 }

--- a/tests/DirectPostGatewayTest.php
+++ b/tests/DirectPostGatewayTest.php
@@ -105,7 +105,7 @@ class DirectPostGatewayTest extends GatewayTestCase
 
     public function testSetTransportAndTimeout()
     {
-        $transport = new class() implements TransportInterface {
+        $transport = new class () implements TransportInterface {
             public function send($method, $url, array $headers = [], $body = '', $timeoutSeconds = 60)
             {
                 return new TransportResponse(200, '{}');

--- a/tests/Message/DirectPostAdvancedFieldsRequestTest.php
+++ b/tests/Message/DirectPostAdvancedFieldsRequestTest.php
@@ -43,4 +43,3 @@ class DirectPostAdvancedFieldsRequestTest extends TestCase
         $this->assertSame('merchant,refid,rescode,restext', $data['EPS_CALLBACKPARAMS']);
     }
 }
-

--- a/tests/Message/DirectPostCaptureRequestTest.php
+++ b/tests/Message/DirectPostCaptureRequestTest.php
@@ -38,7 +38,7 @@ class DirectPostCaptureRequestTest extends TestCase
     {
         $request = $this->request;
 
-        $request->setTransport(new class() implements TransportInterface {
+        $request->setTransport(new class () implements TransportInterface {
             public function send($method, $url, array $headers = [], $body = '', $timeoutSeconds = 60)
             {
                 return new TransportResponse(200, 'rescode=00&restext=Approved&txnid=CAPTURED-1');

--- a/tests/Message/DirectPostFingerprintRequestTest.php
+++ b/tests/Message/DirectPostFingerprintRequestTest.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Omnipay\NABTransact\Message;
+
+use Omnipay\NABTransact\Enums\TransactionType;
+use Omnipay\NABTransact\Tests\Support\TestCase;
+
+/**
+ * Verifies the Direct Post fingerprint is composed using the field order
+ * defined in the NAB Direct Post v2 integration guide (sections 2.3.6.1 -
+ * 2.3.6.4).
+ */
+class DirectPostFingerprintRequestTest extends TestCase
+{
+    private const PASSWORD = 'abcd1234';
+
+    /**
+     * @param array<string,mixed> $overrides
+     *
+     * @return DirectPostPurchaseRequest
+     */
+    private function buildRequest(array $overrides = [])
+    {
+        $request = new DirectPostPurchaseRequest($this->getHttpClient(), $this->getHttpRequest());
+
+        $request->initialize(array_merge([
+            'merchantId'          => 'XYZ0010',
+            'transactionPassword' => self::PASSWORD,
+            'amount'              => '100.00',
+            'currency'            => 'AUD',
+            'returnUrl'           => 'https://www.example.com/return',
+            'transactionId'       => 'ORDER-100',
+            'card'                => [
+                'number'      => '4444333322221111',
+                'expiryMonth' => '12',
+                'expiryYear'  => '2030',
+                'cvv'         => '123',
+            ],
+        ], $overrides));
+
+        return $request;
+    }
+
+    /**
+     * Rebuilds the expected fingerprint from the resulting payload using the
+     * documented field order, then hashes it the same way the gateway does.
+     *
+     * @param array<string,mixed> $data
+     * @param array<int,string>   $orderedFields
+     *
+     * @return string
+     */
+    private function expectedFingerprint(array $data, array $orderedFields)
+    {
+        $parts = [
+            $data['EPS_MERCHANT'],
+            self::PASSWORD,
+            $data['EPS_TXNTYPE'],
+            $data['EPS_REFERENCEID'],
+            $data['EPS_AMOUNT'],
+            $data['EPS_TIMESTAMP'],
+        ];
+
+        foreach ($orderedFields as $field) {
+            $parts[] = $data[$field];
+        }
+
+        return hash_hmac('sha256', implode('|', $parts), self::PASSWORD);
+    }
+
+    public function testStandardFingerprint()
+    {
+        $data = $this->buildRequest()->getData();
+
+        $this->assertSame(
+            $this->expectedFingerprint($data, []),
+            $data['EPS_FINGERPRINT']
+        );
+    }
+
+    public function testSurchargeFingerprintUsesFeeRateAmountOrderAndExcludesEnabledFlag()
+    {
+        $data = $this->buildRequest([
+            'surchargeEnabled' => true,
+            'surchargeFee'     => '7.00',
+            'surchargeRate'    => '5.00',
+            'surchargeAmount'  => '12.00',
+        ])->getData();
+
+        $this->assertSame('true', $data['EPS_SURCHARGEENABLED']);
+
+        $this->assertSame(
+            $this->expectedFingerprint($data, [
+                'EPS_SURCHARGEFEE',
+                'EPS_SURCHARGERATE',
+                'EPS_SURCHARGEAMOUNT',
+            ]),
+            $data['EPS_FINGERPRINT']
+        );
+    }
+
+    public function testEmv3dsFingerprintAppendsOrderId()
+    {
+        $request = $this->buildRequest(['transactionReference' => 'EMV-ORDER-ID-123']);
+        $request->setHasEMV3DSEnabled(true);
+
+        $data = $request->getData();
+
+        $this->assertSame('EMV-ORDER-ID-123', $data['EPS_ORDERID']);
+        $this->assertSame((string) TransactionType::PAYMENT_3DS_EMV3DS, $data['EPS_TXNTYPE']);
+
+        $this->assertSame(
+            $this->expectedFingerprint($data, ['EPS_ORDERID']),
+            $data['EPS_FINGERPRINT']
+        );
+    }
+
+    public function testEmv3dsWithSurchargeOrdersOrderIdBeforeSurcharge()
+    {
+        $request = $this->buildRequest([
+            'transactionReference' => 'EMV-ORDER-ID-123',
+            'surchargeEnabled'     => true,
+            'surchargeFee'         => '7.00',
+            'surchargeRate'        => '5.00',
+            'surchargeAmount'      => '12.00',
+        ]);
+        $request->setHasEMV3DSEnabled(true);
+
+        $data = $request->getData();
+
+        $this->assertSame(
+            $this->expectedFingerprint($data, [
+                'EPS_ORDERID',
+                'EPS_SURCHARGEFEE',
+                'EPS_SURCHARGERATE',
+                'EPS_SURCHARGEAMOUNT',
+            ]),
+            $data['EPS_FINGERPRINT']
+        );
+    }
+
+    public function testMcrFingerprintAppendsCardScheme()
+    {
+        $data = $this->buildRequest(['cardScheme' => 'scheme'])->getData();
+
+        $this->assertSame(
+            $this->expectedFingerprint($data, ['EPS_CARDSCHEME']),
+            $data['EPS_FINGERPRINT']
+        );
+    }
+
+    public function testMcrWithSurchargeOrdersCardSchemeThenSurcharge()
+    {
+        $data = $this->buildRequest([
+            'cardScheme'       => 'scheme',
+            'surchargeEnabled' => true,
+            'surchargeFee'     => '7.00',
+            'surchargeRate'    => '5.00',
+            'surchargeAmount'  => '12.00',
+        ])->getData();
+
+        $this->assertSame(
+            $this->expectedFingerprint($data, [
+                'EPS_CARDSCHEME',
+                'EPS_SURCHARGEFEE',
+                'EPS_SURCHARGERATE',
+                'EPS_SURCHARGEAMOUNT',
+            ]),
+            $data['EPS_FINGERPRINT']
+        );
+    }
+
+    public function testMcrWithSurchargeAndEmv3dsOrdersOrderIdLast()
+    {
+        $request = $this->buildRequest([
+            'transactionReference' => 'EMV-ORDER-ID-123',
+            'cardScheme'           => 'eftpos',
+            'surchargeEnabled'     => true,
+            'surchargeFee'         => '7.00',
+            'surchargeRate'        => '5.00',
+            'surchargeAmount'      => '12.00',
+        ]);
+        $request->setHasEMV3DSEnabled(true);
+
+        $data = $request->getData();
+
+        $this->assertSame(
+            $this->expectedFingerprint($data, [
+                'EPS_CARDSCHEME',
+                'EPS_SURCHARGEFEE',
+                'EPS_SURCHARGERATE',
+                'EPS_SURCHARGEAMOUNT',
+                'EPS_ORDERID',
+            ]),
+            $data['EPS_FINGERPRINT']
+        );
+    }
+}

--- a/tests/Message/DirectPostRefundRequestTest.php
+++ b/tests/Message/DirectPostRefundRequestTest.php
@@ -35,7 +35,7 @@ class DirectPostRefundRequestTest extends TestCase
     {
         $request = $this->request;
 
-        $request->setTransport(new class() implements TransportInterface {
+        $request->setTransport(new class () implements TransportInterface {
             public function send($method, $url, array $headers = [], $body = '', $timeoutSeconds = 60)
             {
                 return new TransportResponse(200, '{"rescode":"00","restext":"Refunded","txnid":"REF-1"}');

--- a/tests/Message/DirectPostReversalRequestTest.php
+++ b/tests/Message/DirectPostReversalRequestTest.php
@@ -35,7 +35,7 @@ class DirectPostReversalRequestTest extends TestCase
     {
         $request = $this->request;
 
-        $request->setTransport(new class() implements TransportInterface {
+        $request->setTransport(new class () implements TransportInterface {
             public function send($method, $url, array $headers = [], $body = '', $timeoutSeconds = 60)
             {
                 return new TransportResponse(200, '<response><rescode>00</rescode><restext>Reversed</restext><txnid>VOID-1</txnid></response>');

--- a/tests/Message/EMV3DSOrderRequestTest.php
+++ b/tests/Message/EMV3DSOrderRequestTest.php
@@ -42,7 +42,7 @@ class EMV3DSOrderRequestTest extends TestCase
 
         $request = $this->request;
         $request->setTimeoutSeconds(15);
-        $request->setTransport(new class($capture) implements TransportInterface {
+        $request->setTransport(new class ($capture) implements TransportInterface {
             private $capture;
 
             public function __construct($capture)
@@ -81,7 +81,7 @@ class EMV3DSOrderRequestTest extends TestCase
     public function testSendHandlesInvalidJsonResponse()
     {
         $request = $this->request;
-        $request->setTransport(new class() implements TransportInterface {
+        $request->setTransport(new class () implements TransportInterface {
             public function send($method, $url, array $headers = [], $body = '', $timeoutSeconds = 60)
             {
                 return new TransportResponse(500, 'Internal Error');

--- a/tests/Message/SecureXMLTransportRequestTest.php
+++ b/tests/Message/SecureXMLTransportRequestTest.php
@@ -29,7 +29,7 @@ class SecureXMLTransportRequestTest extends TestCase
 
         $capture = (object) ['called' => false, 'method' => null, 'url' => null];
 
-        $transport = new class($capture) implements TransportInterface {
+        $transport = new class ($capture) implements TransportInterface {
             private $capture;
 
             public function __construct($capture)

--- a/tests/Message/UnionPayPurchaseRequestTest.php
+++ b/tests/Message/UnionPayPurchaseRequestTest.php
@@ -49,6 +49,16 @@ class UnionPayPurchaseRequestTest extends TestCase
         $this->assertArrayHasKey('EPS_FINGERPRINT', $response->getData());
     }
 
+    public function testAllowsSupportedCurrencyForUpop()
+    {
+        $this->request->setCurrency('AUD');
+
+        $data = $this->request->getData();
+
+        $this->assertSame('UPOP', $data['EPS_PAYMENTCHOICE']);
+        $this->assertSame('AUD', $data['EPS_CURRENCY']);
+    }
+
     public function testRejectsUnsupportedCurrencyForUpop()
     {
         $this->request->setCurrency('USD');

--- a/tests/SecureXMLGatewayTest.php
+++ b/tests/SecureXMLGatewayTest.php
@@ -74,7 +74,7 @@ class SecureXMLGatewayTest extends GatewayTestCase
 
     public function testTransportAndTimeoutArePassedToRequest()
     {
-        $transport = new class() implements TransportInterface {
+        $transport = new class () implements TransportInterface {
             public function send($method, $url, array $headers = [], $body = '', $timeoutSeconds = 60)
             {
                 return new TransportResponse(200, '<NABTransactMessage><Status><statusCode>000</statusCode><statusDescription>Normal</statusDescription></Status><RequestType>Echo</RequestType></NABTransactMessage>');

--- a/tests/Support/MockHttpClient.php
+++ b/tests/Support/MockHttpClient.php
@@ -49,7 +49,7 @@ final class MockHttpClient implements ClientInterface
         ];
 
         if (empty($this->responses)) {
-            throw new RuntimeException('No queued mock HTTP response for '.$method.' '.$uri);
+            throw new RuntimeException('No queued mock HTTP response for ' . $method . ' ' . $uri);
         }
 
         $response = array_shift($this->responses);

--- a/tests/Support/MockStream.php
+++ b/tests/Support/MockStream.php
@@ -96,7 +96,7 @@ final class MockStream implements StreamInterface
             $suffix = substr($this->content, $suffixStart);
         }
 
-        $this->content = $prefix.$string.$suffix;
+        $this->content = $prefix . $string . $suffix;
         $this->position += strlen($string);
 
         return strlen($string);
@@ -142,4 +142,3 @@ final class MockStream implements StreamInterface
         return null;
     }
 }
-

--- a/tests/Support/TestCase.php
+++ b/tests/Support/TestCase.php
@@ -47,15 +47,15 @@ class TestCase extends PHPUnitTestCase
 
     protected function fixtureContents(string $filename): string
     {
-        $path = dirname(__DIR__).'/Mock/'.$filename;
+        $path = dirname(__DIR__) . '/Mock/' . $filename;
 
         if (!is_file($path)) {
-            $this->fail('Missing mock HTTP fixture: '.$filename);
+            $this->fail('Missing mock HTTP fixture: ' . $filename);
         }
 
         $body = file_get_contents($path);
         if ($body === false) {
-            $this->fail('Unable to read mock HTTP fixture: '.$filename);
+            $this->fail('Unable to read mock HTTP fixture: ' . $filename);
         }
 
         // Legacy fixture files may contain an HTTP status line and headers.

--- a/tests/Transport/OmnipayHttpClientTransportTest.php
+++ b/tests/Transport/OmnipayHttpClientTransportTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Omnipay\NABTransact\Transport;
+
+use Nyholm\Psr7\Response;
+use Omnipay\Common\Http\ClientInterface;
+use Omnipay\NABTransact\Tests\Support\TestCase;
+
+class OmnipayHttpClientTransportTest extends TestCase
+{
+    public function testSendForwardsRequestAndMapsPsrResponse()
+    {
+        $capture = (object) ['method' => null, 'uri' => null, 'headers' => [], 'body' => null];
+
+        $client = new class ($capture) implements ClientInterface {
+            private $capture;
+
+            public function __construct($capture)
+            {
+                $this->capture = $capture;
+            }
+
+            public function request($method, $uri, array $headers = [], $body = null, $protocolVersion = '1.1')
+            {
+                $this->capture->method = $method;
+                $this->capture->uri = $uri;
+                $this->capture->headers = $headers;
+                $this->capture->body = $body;
+
+                return new Response(201, [], '{"orderId":"ORDER-1"}');
+            }
+        };
+
+        $transport = new OmnipayHttpClientTransport($client);
+
+        $response = $transport->send('post', 'https://example.test/orders', ['X-Test' => 'yes'], '{"k":"v"}', 15);
+
+        $this->assertSame('POST', $capture->method);
+        $this->assertSame('https://example.test/orders', $capture->uri);
+        $this->assertSame(['X-Test' => 'yes'], $capture->headers);
+        $this->assertSame('{"k":"v"}', $capture->body);
+
+        $this->assertInstanceOf(TransportResponse::class, $response);
+        $this->assertSame(201, $response->getStatusCode());
+        $this->assertSame('{"orderId":"ORDER-1"}', $response->getBody());
+    }
+
+    public function testSendCastsNonStandardStatusAndEmptyBody()
+    {
+        $client = new class () implements ClientInterface {
+            public function request($method, $uri, array $headers = [], $body = null, $protocolVersion = '1.1')
+            {
+                return new Response(204, [], '');
+            }
+        };
+
+        $response = (new OmnipayHttpClientTransport($client))->send('GET', 'https://example.test/ping');
+
+        $this->assertSame(204, $response->getStatusCode());
+        $this->assertSame('', $response->getBody());
+    }
+}


### PR DESCRIPTION
The fingerprint built the surcharge values in amount/rate/fee order and
included EPS_SURCHARGEENABLED in the hash. Per the Direct Post v2 guide
(2.3.6.2) the surcharge values must be ordered fee, rate, amount and the
enabled flag is a form-only field that is never hashed. The MCR card
scheme and EMV 3DS order id positions were also corrected to match
2.3.6.3 and 2.3.6.4: the card scheme follows the timestamp and the order
id is appended last when a card scheme is present, otherwise it precedes
any surcharge values.

Add coverage asserting the fingerprint composition for every documented
combination.
